### PR TITLE
Proper, node-js style error handling for set_crontab

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -6,6 +6,15 @@ function infoMessageBox(message, title){
 	$("#info-title").html(title);
 	$("#info-popup").modal('show');
 }
+// like info, but for errors.
+function errorMessageBox(message) {
+	var msg =
+		"Operation failed: " + message + ". " +
+		"Please see error log for details.";
+	$("#info-body").html(msg);
+	$("#info-title").html("Error");
+	$("#info-popup").modal('show');
+}
 // modal with full control
 function messageBox(body, title, ok_text, close_text, callback){
 	$("#modal-body").html(body);
@@ -50,6 +59,8 @@ function setCrontab(){
 		$.get(routes.crontab, { "env_vars": $("#env_vars").val() }, function(){
 			// TODO show only if success
 			infoMessageBox("Successfuly set crontab file!","Information");
+		}).fail(function(response) {
+			errorMessageBox(response.statusText,"Error");
 		});
 	});
 }


### PR DESCRIPTION
Current code has almost zero proper error handling. Errors are getting ignored and the UI shows success even though the requested operation did not succeed at all.

I started to implement proper error handling for set_crontab. `fs.writeFile` and `exec` callbacks are registered properly, errors are bubbled up to the route handler and forwarded to express error handling middleware. UI will receive errors and show a warning dialog.

Any errors with the db initialisation are also not handled at all - if the DB cannot be created for some reason the errors are ignored and lead to weird behaviour later. Since w/o DB the app is in an unusable state, I just immediately throw the error, terminating the process.
