### PR TITLE
Supervisord to run webui, and cron at the same time.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ LABEL description "Crontab-UI docker"
 RUN   apk --no-cache add \
       nodejs \
       wget \
-      curl
+      curl \
+      supervisor
+
+COPY supervisord.conf /etc/supervisord.conf      
 
 RUN   npm install -g crontab-ui
 
@@ -17,4 +20,4 @@ ENV   PORT 8000
 
 EXPOSE $PORT
 
-CMD ["crontab-ui"]
+CMD ["supervisord", "-c", "/etc/supervisord.conf"]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,12 @@
+[supervisord]
+nodaemon=true
+
+[program:crontab]
+command=crond -l 2 -f
+stderr_logfile = /var/log/crontab-stderr.log
+stdout_logfile = /var/log/crontab-stdout.log
+
+[program:crontabui]
+command=crontab-ui
+stderr_logfile = /var/log/crontabui-stderr.log
+stdout_logfile = /var/log/crontabui-stdout.log


### PR DESCRIPTION
The alpine linux doesn't start crond automatically.    Using this method, supervisor starts the busybox crond and crontab-ui node application.   This way the jobs actually run inside docker.