### PR TITLE
Update base image to a supported tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # docker run -d -p 8000:8000 alseambusher/crontab-ui
-FROM alpine:3.5
+FROM alpine:3.10
 
 RUN   mkdir /crontab-ui; touch /etc/crontabs/root; chmod +x /etc/crontabs/root
 


### PR DESCRIPTION
Hi!

I was looking into using this image to replace my current cron daemon, but inspecting the Dockerfile I ralized that it's based on  `alpine:3.5`, which according to [Alpine's releases list](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases) is EOL since 2018-11.

So, seeing that this looks like a really cool tool, I changed the FROM line of the Dockerfile to base the container in `node:10-alpine` which is itself based on `alpine:3.9` which still has one year ahead.

As far as I can tell, everything works as expected, but as I couldn't find tests to run, it would probably be a good idea for someone more familiar with the software to test it.