### PR TITLE
[add] Tzdata to configure timezone on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN   apk --no-cache add \
       curl \
       nodejs \
       npm \
-      supervisor
+      supervisor \
+      tzdata
 
 COPY supervisord.conf /etc/supervisord.conf
 COPY . /crontab-ui


### PR DESCRIPTION
Added tzdata which is needed in alpine to configure the timezone based on the docker built in TZ env otherwise the cronjobs run in UTC even when the TZ env has been set

Example usage
```bash
docker run -d --name crontab-ui -p 8000:8000 -e TZ=America/Mexico_City alseambusher/crontab-ui:latest
```
