### PR TITLE
Fix log dir error on docker if not created

### DIFF
--- a/crontab.js
+++ b/crontab.js
@@ -26,6 +26,9 @@ var cron_parser = require("cron-parser");
 var cronstrue = require('cronstrue/i18n');
 var humanCronLocate = process.env.HUMANCRON ?? "en"
 
+if (!fs.existsSync(exports.log_folder)){
+    fs.mkdirSync(exports.log_folder);
+}
 
 crontab = function(name, command, schedule, stopped, logging, mailing){
 	var data = {};


### PR DESCRIPTION
On Docker, if you mount logs and db dir from host, and logs folder doesn't exist, cron task cant create the log dir, so you won't be able to read them at the folder expected.
This PR checks if the log dir exists and if not it makes a new one.