### PR TITLE
fix: replace removed parseString with parseExpression for cron-parser v5 compat

### DIFF
--- a/crontab.js
+++ b/crontab.js
@@ -273,7 +273,7 @@ exports.import_crontab = function(){
 			var schedule = line.replace(command, '').trim();
 
 			var is_valid = false;
-			try { is_valid = cron_parser.parseString(line).expressions.length > 0; } catch (e){}
+			try { cron_parser.parseExpression(line); is_valid = true; } catch (e){}
 
 			if(command && schedule && is_valid){
 				var name = namePrefix + '_' + index;


### PR DESCRIPTION
## Bug

`package.json` pins `cron-parser` to `"latest"`, which now resolves to v5.x. In v5, `parseString()` was removed. The import feature on line 276 calls `cron_parser.parseString(line)`, which throws silently, causing the import to produce an empty database with no error shown to the user.

## Fix

Replace `parseString(line).expressions.length > 0` with `parseExpression(line)` — `parseExpression` still exists in v5 and throws on invalid input, so the existing try/catch handles validation the same way.

Closes #268