### PR TITLE
Auto-backup on import, fix log display, and support multi-line commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.4.1
 
 release:
 	sed -i '' "s/version\": \".*/version\": \"$(VER)\",/" package.json

--- a/app.js
+++ b/app.js
@@ -163,21 +163,27 @@ app.get(routes.export, (req, res) => {
   fs.createReadStream(file).pipe(res);
 });
 
-app.post(routes.import, (req, res) => {
-  req.pipe(req.busboy);
-  req.busboy.on('file', (_fieldname, file) => {
-    const fstream = fs.createWriteStream(crontab.crontab_db_file);
-    file.pipe(fstream);
-    fstream.on('close', () => {
-      crontab.reload_db();
-      res.redirect(routes.root);
+app.post(routes.import, (req, res, next) => {
+  crontab.backup((err) => {
+    if (err) return next(err);
+    req.pipe(req.busboy);
+    req.busboy.on('file', (_fieldname, file) => {
+      const fstream = fs.createWriteStream(crontab.crontab_db_file);
+      file.pipe(fstream);
+      fstream.on('close', () => {
+        crontab.reload_db();
+        res.redirect(routes.root);
+      });
     });
   });
 });
 
-app.get(routes.import_crontab, (req, res) => {
-  crontab.import_crontab();
-  res.end();
+app.get(routes.import_crontab, (req, res, next) => {
+  crontab.backup((err) => {
+    if (err) return next(err);
+    crontab.import_crontab();
+    res.end();
+  });
 });
 
 app.get(routes.view_crontab, (req, res) => {
@@ -189,9 +195,11 @@ app.get(routes.view_crontab, (req, res) => {
 
 function sendLog(filePath, req, res) {
   if (fs.existsSync(filePath)) {
+    res.type('text/plain');
+    res.set('Cache-Control', 'no-store');
     res.sendFile(filePath);
   } else {
-    res.end('No errors logged yet');
+    res.type('text/plain').send('No errors logged yet');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crontab-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Easy and safe way to manage your crontab file",
   "main": "app.js",
   "scripts": {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -93,7 +93,7 @@ function setCrontab() {
 
 function getCrontab() {
   messageBox(
-    '<p> Do you want to get the crontab file? <br /> <b class="text-danger">NOTE: It is recommended to take a backup before this.</b> And refresh the page after this.</p>',
+    '<p> Do you want to get the crontab file? <br /> A backup will be created automatically before importing.</p>',
     'Confirm crontab retrieval', null, null, function() {
       $.get(routes.import_crontab, { 'env_vars': $('#env_vars').val() }, function() {
         infoMessageBox('Successfully got the crontab file!', 'Information');
@@ -138,7 +138,7 @@ function editJob(_id) {
     var name = $('#job-name').val();
     var mailing = JSON.parse($('#job-mailing').attr('data-json'));
     var logging = $('#job-logging').prop('checked');
-    $.post(routes.save, {name: name, command: job_command, schedule: schedule, _id: _id, logging: logging, mailing: mailing}, function() {
+    $.post(routes.save, {name: name, command: collapsedCommand(), schedule: schedule, _id: _id, logging: logging, mailing: mailing}, function() {
       location.reload();
     });
     getModal('job').hide();
@@ -169,7 +169,7 @@ function newJob() {
     var name = $('#job-name').val();
     var mailing = JSON.parse($('#job-mailing').attr('data-json'));
     var logging = $('#job-logging').prop('checked');
-    $.post(routes.save, {name: name, command: job_command, schedule: schedule, _id: -1, logging: logging, mailing: mailing}, function() {
+    $.post(routes.save, {name: name, command: collapsedCommand(), schedule: schedule, _id: -1, logging: logging, mailing: mailing}, function() {
       location.reload();
     });
     getModal('job').hide();
@@ -225,7 +225,7 @@ function restore_backup(db_name) {
 
 function import_db() {
   messageBox(
-    '<p> Do you want to import crontab?<br /> <b class="text-danger">NOTE: It is recommended to take a backup before this.</b> </p>',
+    '<p> Do you want to import crontab?<br /> A backup will be created automatically before importing.</p>',
     'Confirm import from crontab', null, null, function() {
       $('#import_file').click();
     });
@@ -306,9 +306,14 @@ function setHookConfig(a) {
   messageBox('<p>Coming Soon</p>', 'Hooks', null, null, null);
 }
 
+function collapsedCommand() {
+  return job_command.split(/\r?\n/).map(function(l) { return l.trim(); }).filter(Boolean).join('; ');
+}
+
 function job_string() {
-  $('#job-string').val(schedule + ' ' + job_command);
-  return schedule + ' ' + job_command;
+  var cmd = collapsedCommand();
+  $('#job-string').val(schedule + ' ' + cmd);
+  return schedule + ' ' + cmd;
 }
 
 function set_schedule() {

--- a/tests/test.js
+++ b/tests/test.js
@@ -211,6 +211,22 @@ describe('Crontab UI', () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain('No errors logged yet');
     });
+
+    it('should return text/plain content type when no log exists', async () => {
+      const res = await request(app).get('/logger?id=nonexistent');
+      expect(res.headers['content-type']).toContain('text/plain');
+    });
+
+    it('should return text/plain and no-store when log file exists', async () => {
+      const logFile = path.join(testDbPath, 'logs', 'testlog.log');
+      fs.writeFileSync(logFile, 'some error output\n');
+      const res = await request(app).get('/logger?id=testlog');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/plain');
+      expect(res.headers['cache-control']).toBe('no-store');
+      expect(res.text).toContain('some error output');
+      fs.unlinkSync(logFile);
+    });
   });
 
   describe('GET /stdout', () => {
@@ -218,6 +234,64 @@ describe('Crontab UI', () => {
       const res = await request(app).get('/stdout?id=nonexistent');
       expect(res.status).toBe(200);
       expect(res.text).toContain('No errors logged yet');
+    });
+
+    it('should return text/plain content type when no log exists', async () => {
+      const res = await request(app).get('/stdout?id=nonexistent');
+      expect(res.headers['content-type']).toContain('text/plain');
+    });
+
+    it('should return text/plain and no-store when stdout log exists', async () => {
+      const logFile = path.join(testDbPath, 'logs', 'teststdout.stdout.log');
+      fs.writeFileSync(logFile, 'some stdout output\n');
+      const res = await request(app).get('/stdout?id=teststdout');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/plain');
+      expect(res.headers['cache-control']).toBe('no-store');
+      expect(res.text).toContain('some stdout output');
+      fs.unlinkSync(logFile);
+    });
+  });
+
+  describe('GET /import_crontab (auto-backup)', () => {
+    it('should create a backup before importing', async () => {
+      // ensure a job exists so crontab.db is non-empty
+      await request(app).post('/save').send({
+        _id: -1, name: 'backup-test', command: 'echo backup',
+        schedule: '* * * * *', logging: 'false', mailing: {},
+      });
+      // small delay so backup filename (based on date) doesn't collide
+      await new Promise((r) => setTimeout(r, 1100));
+      const backupsBefore = fs.readdirSync(testDbPath)
+        .filter((f) => f.startsWith('backup'));
+      await request(app).get('/import_crontab');
+      const backupsAfter = fs.readdirSync(testDbPath)
+        .filter((f) => f.startsWith('backup'));
+      expect(backupsAfter.length).toBe(backupsBefore.length + 1);
+    });
+  });
+
+  describe('POST /import (auto-backup)', () => {
+    it('should create a backup before importing a db file', async () => {
+      // small delay so backup filename (based on date) doesn't collide
+      await new Promise((r) => setTimeout(r, 1100));
+      const backupsBefore = fs.readdirSync(testDbPath)
+        .filter((f) => f.startsWith('backup'));
+      const dbContent = fs.readFileSync(path.join(testDbPath, 'crontab.db'));
+      await request(app)
+        .post('/import')
+        .attach('file', dbContent, 'crontab.db');
+      const backupsAfter = fs.readdirSync(testDbPath)
+        .filter((f) => f.startsWith('backup'));
+      expect(backupsAfter.length).toBe(backupsBefore.length + 1);
+    });
+  });
+
+  describe('Command textarea', () => {
+    it('should render a textarea for the command field', async () => {
+      const res = await request(app).get('/');
+      expect(res.text).toContain('<textarea');
+      expect(res.text).toContain('id=\'job-command\'');
     });
   });
 });

--- a/views/popup.ejs
+++ b/views/popup.ejs
@@ -10,7 +10,7 @@
 	<label class="form-label">Name (Optional)</label>
 	<input type='text' class='form-control' id='job-name'/><br />
 	<label class="form-label">Command</label>
-	<input type='text' class='form-control' id='job-command' onkeyup="job_command = $(this).val(); job_string();"/><br />
+	<textarea class='form-control' id='job-command' rows='3' oninput="job_command = $(this).val(); job_string();"></textarea><br />
 	<label class="form-label">Quick Schedule</label><br />
 	<div class="d-flex flex-wrap gap-2 mb-3">
 		<a class="btn btn-primary btn-sm" onclick="schedule = '* * * * *'; job_string();">Every Minute</a>


### PR DESCRIPTION
## Summary

- Automatically create a backup before "Get from crontab" and DB file import so users don't accidentally lose data ([#242](https://github.com/alseambusher/crontab-ui/issues/242))
- Fix log endpoints to serve `text/plain` with `no-store` caching so browsers display logs inline instead of downloading them ([#240](https://github.com/alseambusher/crontab-ui/issues/240), [#238](https://github.com/alseambusher/crontab-ui/issues/238))
- Change command input to a multi-line textarea; newlines are collapsed to semicolons before saving ([#239](https://github.com/alseambusher/crontab-ui/issues/239))

## Test plan

- [x] `GET /import_crontab` creates a backup file before importing from system crontab
- [x] `POST /import` creates a backup file before importing a DB upload
- [x] `GET /logger` and `GET /stdout` return `Content-Type: text/plain` and `Cache-Control: no-store` for both existing and missing log files
- [x] Main page renders a `<textarea>` for the command field
- [x] All 28 tests pass (`npm test`)