### PR TITLE
Rename View crontab to Preview crontab with unsaved changes warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VER=0.4.1
+VER=0.4.2
 
 release:
 	sed -i '' "s/version\": \".*/version\": \"$(VER)\",/" package.json

--- a/app.js
+++ b/app.js
@@ -186,7 +186,7 @@ app.get(routes.import_crontab, (req, res, next) => {
   });
 });
 
-app.get(routes.view_crontab, (req, res) => {
+app.get(routes.preview_crontab, (req, res) => {
   const envVars = crontab.get_env();
   crontab.preview_crontab(envVars, (result) => {
     res.type('text/plain').send(result);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crontab-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Easy and safe way to manage your crontab file",
   "main": "app.js",
   "scripts": {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -321,17 +321,17 @@ function set_schedule() {
   job_string();
 }
 
-function viewCrontab() {
-  $.get(routes.view_crontab, function(data) {
-    document.getElementById('view-crontab-content').textContent = data || '# (empty crontab)';
-    getModal('view-crontab-modal').show();
+function previewCrontab() {
+  $.get(routes.preview_crontab, function(data) {
+    document.getElementById('preview-crontab-content').textContent = data || '# (empty crontab)';
+    getModal('preview-crontab-modal').show();
   });
 }
 
 function copyCrontab() {
-  var text = document.getElementById('view-crontab-content').textContent;
+  var text = document.getElementById('preview-crontab-content').textContent;
   navigator.clipboard.writeText(text).then(function() {
-    var btn = document.querySelector('#view-crontab-modal .btn-outline-secondary');
+    var btn = document.querySelector('#preview-crontab-modal .btn-outline-secondary');
     btn.innerHTML = '<i class="bi bi-check2"></i> Copied!';
     setTimeout(function() {
       btn.innerHTML = '<i class="bi bi-clipboard"></i> Copy';

--- a/routes.js
+++ b/routes.js
@@ -19,7 +19,7 @@ const routes = {
   import_crontab: '/import_crontab',
   logger: '/logger',
   stdout: '/stdout',
-  view_crontab: '/view_crontab',
+  preview_crontab: '/preview_crontab',
 };
 
 exports.base_url = baseUrl;

--- a/tests/test.js
+++ b/tests/test.js
@@ -122,16 +122,16 @@ describe('Crontab UI', () => {
     });
   });
 
-  describe('GET /view_crontab', () => {
+  describe('GET /preview_crontab', () => {
     it('should return the crontab preview as plain text', async () => {
-      const res = await request(app).get('/view_crontab');
+      const res = await request(app).get('/preview_crontab');
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toContain('text/plain');
       expect(res.text).toContain('echo hello');
     });
 
     it('should include the make_command wrapper (tee pipeline)', async () => {
-      const res = await request(app).get('/view_crontab');
+      const res = await request(app).get('/preview_crontab');
       expect(res.text).toContain('tee');
       expect(res.text).toContain('stderr');
     });
@@ -143,7 +143,7 @@ describe('Crontab UI', () => {
 
       await request(app).post('/stop').send({ _id: match[1] });
 
-      const res = await request(app).get('/view_crontab');
+      const res = await request(app).get('/preview_crontab');
       const lines = res.text.trim().split('\n').filter((l) => l.includes('echo hello'));
       const activePage = await request(app).get('/');
       const activeCount = (activePage.text.match(/stopJob\('/g) || []).length;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -43,7 +43,7 @@
 		<a class="btn btn-warning" href="<%= JSON.parse(routes).export %>"><i class="bi bi-box-arrow-up"></i> Export</a>
 		<a class="btn btn-success" onclick="getCrontab();"><i class="bi bi-arrow-down-circle"></i> Get from crontab</a>
 		<a class="btn btn-success" onclick="setCrontab();"><i class="bi bi-save"></i> Save to crontab</a>
-		<a class="btn btn-outline-secondary" onclick="viewCrontab();"><i class="bi bi-code-square"></i> View crontab</a>
+		<a class="btn btn-outline-secondary" onclick="previewCrontab();"><i class="bi bi-code-square"></i> Preview crontab</a>
 	</div>
 
 	<table class="table table-striped" id="main_table">

--- a/views/popup.ejs
+++ b/views/popup.ejs
@@ -92,15 +92,16 @@
   </div>
 </div>
 
-<div class="modal fade" id="view-crontab-modal" tabindex="-1">
+<div class="modal fade" id="preview-crontab-modal" tabindex="-1">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><i class="bi bi-code-square"></i> Current Crontab</h5>
+        <h5 class="modal-title"><i class="bi bi-code-square"></i> Crontab Preview</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <pre id="view-crontab-content" class="bg-dark text-light p-3 rounded" style="min-height:200px;white-space:pre-wrap;word-break:break-all;font-size:0.875rem;"></pre>
+        <div class="alert alert-warning mb-3"><i class="bi bi-exclamation-triangle"></i> This is a preview of what will be deployed. It may differ from the currently active crontab if you have unsaved changes.</div>
+        <pre id="preview-crontab-content" class="bg-dark text-light p-3 rounded" style="min-height:200px;white-space:pre-wrap;word-break:break-all;font-size:0.875rem;"></pre>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-outline-secondary" onclick="copyCrontab()"><i class="bi bi-clipboard"></i> Copy</button>


### PR DESCRIPTION
## Summary

- Rename "View crontab" to "Preview crontab" across the UI, routes, and JS to clarify that the modal shows a generated preview, not the active system crontab
- Add a warning banner in the preview modal: "This is a preview of what will be deployed. It may differ from the currently active crontab if you have unsaved changes."
- Version bump to 0.4.2

## Test plan

- [x] All 28 tests pass (`npm test`)
- [x] Route renamed from `/view_crontab` to `/preview_crontab`
- [x] Button, modal, and JS functions all updated consistently

Made with [Cursor](https://cursor.com)